### PR TITLE
Fix: SignUp request/response dto 생성, 회원가입 시 UserEntity가 아닌 SignUpResponse를 반환하도록 수정

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/dto/Auth.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/Auth.java
@@ -3,6 +3,8 @@ package com.zerobase.BankSSun.dto;
 import com.zerobase.BankSSun.domain.entity.UserEntity;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 public class Auth {
 
@@ -13,22 +15,5 @@ public class Auth {
         private String password;
     }
 
-    @Data // setter 가 있어야 회원정보 저장 가능
-    @Builder
-    public static class SignUp {
 
-        private String username;
-        private String phone;
-        private String password;
-        private String role;
-
-        public UserEntity toEntity() {
-            return UserEntity.builder()
-                .phone(this.phone)
-                .username(this.username)
-                .password(this.password)
-                .role(this.role)
-                .build();
-        }
-    }
 }

--- a/src/main/java/com/zerobase/BankSSun/dto/SignUpDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/SignUpDto.java
@@ -1,0 +1,39 @@
+package com.zerobase.BankSSun.dto;
+
+import com.zerobase.BankSSun.domain.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class SignUpDto {
+
+    @Getter
+    @Setter // setter 가 있어야 회원정보 저장 가능
+    @Builder
+    public static class SignUpRequest {
+
+        private String username;
+        private String phone;
+        private String password;
+        private String role;
+
+        public UserEntity toEntity() {
+            return UserEntity.builder()
+                .phone(this.phone)
+                .username(this.username)
+                .password(this.password)
+                .role(this.role)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    public static class SignUpResponse {
+
+        private Long id;
+        private String username;
+        private String phone;
+        private String role;
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/service/UserService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/UserService.java
@@ -1,5 +1,8 @@
 package com.zerobase.BankSSun.service;
 
+import static com.zerobase.BankSSun.type.ErrorCode.ALREADY_EXISTS_PHONE;
+
+import com.zerobase.BankSSun.dto.SignUpDto.SignUpRequest;
 import com.zerobase.BankSSun.exception.UserException;
 import com.zerobase.BankSSun.dto.Auth;
 import com.zerobase.BankSSun.domain.repository.UserRepository;
@@ -33,10 +36,10 @@ public class UserService implements UserDetailsService {
      * 회원가입_23.07.25
      */
     @Transactional
-    public UserEntity signUp(Auth.SignUp user) {
+    public UserEntity signUp(SignUpRequest user) {
         boolean exists = this.userRepository.existsByPhone(user.getPhone());
         if (exists) {
-            throw new UserException(ErrorCode.ALREADY_EXISTS_PHONE);
+            throw new UserException(ALREADY_EXISTS_PHONE);
         }
 
         user.setPassword(this.passwordEncoder.encode(user.getPassword()));
@@ -48,7 +51,7 @@ public class UserService implements UserDetailsService {
      */
     public UserEntity authenticate(Auth.SignIn user) {
         UserEntity userEntity = this.userRepository.findByPhone(user.getPhone())
-            .orElseThrow(() -> new UserException(ErrorCode.ALREADY_EXISTS_PHONE));
+            .orElseThrow(() -> new UserException(ALREADY_EXISTS_PHONE));
 
         if (!this.passwordEncoder.matches(user.getPassword(), userEntity.getPassword())) {
             throw new UserException(ErrorCode.PASSWORD_NOT_MATCH);

--- a/src/main/java/com/zerobase/BankSSun/web/AuthController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AuthController.java
@@ -2,6 +2,8 @@ package com.zerobase.BankSSun.web;
 
 import com.zerobase.BankSSun.dto.Auth;
 import com.zerobase.BankSSun.domain.entity.UserEntity;
+import com.zerobase.BankSSun.dto.SignUpDto.SignUpRequest;
+import com.zerobase.BankSSun.dto.SignUpDto.SignUpResponse;
 import com.zerobase.BankSSun.security.TokenProvider;
 import com.zerobase.BankSSun.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +24,18 @@ public class AuthController {
     private final TokenProvider tokenProvider;
 
     /**
-     * 회원가입 api_23.07.16
+     * 회원가입 api_23.07.25
      */
     @PostMapping("/sign-up")
-    public ResponseEntity<UserEntity> signUp(@RequestBody Auth.SignUp request) {
+    public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest request) {
         UserEntity userEntity = this.userService.signUp(request);
-        return ResponseEntity.ok(userEntity);
+        return ResponseEntity.ok(
+            SignUpResponse.builder()
+                .id(userEntity.getId())
+                .phone(userEntity.getPhone())
+                .role(userEntity.getRole())
+                .username(userEntity.getUsername())
+                .build());
     }
 
 

--- a/src/test/java/com/zerobase/BankSSun/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/BankSSun/service/UserServiceTest.java
@@ -3,7 +3,7 @@ package com.zerobase.BankSSun.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.zerobase.BankSSun.domain.entity.UserEntity;
-import com.zerobase.BankSSun.dto.Auth.SignUp;
+import com.zerobase.BankSSun.dto.SignUpDto.SignUpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +22,7 @@ class UserServiceTest {
     @DisplayName("회원가입")
     void signUp() {
         //given
-        SignUp form = SignUp.builder()
+        SignUpRequest form = SignUpRequest.builder()
             .phone("01012345678")
             .username("test")
             .password("101010")


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
1. 회원가입 관련 dto는 요청시 받는 형식을 지정한 SignUp 클래스만 존재했음
1. 회원가입 api 요청 시 성공 응답으로 UserEntity를 반환하여 오류를 발생하거나 보안에 취약할 수 있는 상황이었음.

**🌷 TO-BE**
1. 회원가입 관련 dto를 SignUpRequest, SignUpResponse로 나누었음.
2. 회원가입 api 성공응답으로 SignUpResponse를 반환함

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

---

### 🗣️ COMMENT
1. 중복된 전화번호로 api 요청시 Exception 메세지가 떠야하는데 안떠서 수정해봤는데도 안뜨고 null이라고 뜹니다.
이 부분은 다른 pr에서 수정될 예정입니다.