### PR TITLE
Feat: 계좌 생성 api 완성

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
@@ -1,0 +1,46 @@
+package com.zerobase.BankSSun.domain.entity;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor // => 필요한 것 맞는가..!
+//@NoArgsConstructor
+@Entity(name = "ACCOUNT")
+@AuditOverride(forClass = BaseEntity.class)
+public class AccountEntity extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private String accountNumber;
+
+    @NotNull
+    private String accountName;
+
+    @NotNull
+    private Long amount;
+
+    @NotNull
+    private Boolean isDeleted;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/zerobase/BankSSun/domain/repository/AccountRepository.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/repository/AccountRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.BankSSun.domain.repository;
+
+import com.zerobase.BankSSun.domain.entity.AccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<AccountEntity, Long> {
+
+    boolean existsByAccountNumber(String accountNumber);
+}

--- a/src/main/java/com/zerobase/BankSSun/domain/repository/AccountRepository.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/repository/AccountRepository.java
@@ -1,11 +1,12 @@
 package com.zerobase.BankSSun.domain.repository;
 
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccountRepository extends JpaRepository<AccountEntity, Long> {
 
-    boolean existsByAccountNumber(String accountNumber);
+    Optional<AccountEntity> findFirstByOrderByIdDesc();
 }

--- a/src/main/java/com/zerobase/BankSSun/dto/AccountCreateDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/AccountCreateDto.java
@@ -15,6 +15,7 @@ public class AccountCreateDto {
         @NotNull
         @Min(1)
         private Long userId;
+        private String accountName;
         @NotNull
         @Min(0)
         private Long initialBalance;

--- a/src/main/java/com/zerobase/BankSSun/dto/AccountCreateDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/AccountCreateDto.java
@@ -1,0 +1,32 @@
+package com.zerobase.BankSSun.dto;
+
+import java.time.LocalDateTime;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AccountCreateDto {
+
+    @Getter
+    @Builder
+    public static class Request {
+
+        @NotNull
+        @Min(1)
+        private Long userId;
+        @NotNull
+        @Min(0)
+        private Long initialBalance;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+
+        private Long userId;
+        private String accountNumber;
+        private Long amount;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
@@ -35,6 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 토큰 유효성 검증
             Authentication auth = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
+        } else {
+            throw new RuntimeException("유효하지 않은 토큰입니다");
         }
         // 다음 filter-chain 실행
         filterChain.doFilter(request, response);

--- a/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
@@ -28,6 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
+        // 다음 필터 실행 전 처리하는 로직
         String token = resolveTokenFromRequest(request);
 
         if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
@@ -35,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Authentication auth = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
         }
-
+        // 다음 filter-chain 실행
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/BankSSun/security/JwtAuthenticationFilter.java
@@ -35,8 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 토큰 유효성 검증
             Authentication auth = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
-        } else {
-            throw new RuntimeException("유효하지 않은 토큰입니다");
         }
         // 다음 filter-chain 실행
         filterChain.doFilter(request, response);

--- a/src/main/java/com/zerobase/BankSSun/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/BankSSun/security/TokenProvider.java
@@ -29,8 +29,10 @@ public class TokenProvider {
     /**
      * 토큰 생성(발급)_23.07.21
      */
-    public String generateToken(String phone, String role) {
-        Claims claims = Jwts.claims().setSubject(phone); // 사용자의 정보를 저장하기 위한 claim
+    public String generateToken(Long userId, String phone, String role) {
+        Claims claims = Jwts.claims() // 사용자의 정보를 저장하기 위한 claim
+            .setSubject(phone)
+            .setId(userId + "");
         claims.put(KEY_ROLE, role);
 
         Date now = new Date();
@@ -45,10 +47,10 @@ public class TokenProvider {
     }
 
     /**
-     * jwt 에서 인증정보 추출_23.07.21
+     * jwt 에서 인증정보 추출_23.07.31
      */
-    public Authentication getAuthentication(String jwt) {
-        UserDetails userDetails = userService.loadUserByUsername(getPhone(jwt));
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userService.loadUserByUsername(getPhone(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "",
             userDetails.getAuthorities());
     }
@@ -58,6 +60,13 @@ public class TokenProvider {
      */
     public String getPhone(String token) {
         return parseClaims(token).getSubject();
+    }
+
+    /**
+     * 토큰에서 사용자 id 추출_23.08.01
+     */
+    public Long getId(String token) {
+        return Long.parseLong(parseClaims(token).getId());
     }
 
     /**

--- a/src/main/java/com/zerobase/BankSSun/service/AccountService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/AccountService.java
@@ -1,12 +1,9 @@
 package com.zerobase.BankSSun.service;
 
-import static com.zerobase.BankSSun.type.ErrorCode.TOKEN_EXPIRED;
-
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.domain.repository.AccountRepository;
 import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.AccountCreateDto;
-import com.zerobase.BankSSun.exception.UserException;
 import com.zerobase.BankSSun.security.TokenProvider;
 import java.util.Objects;
 import javax.transaction.Transactional;
@@ -29,15 +26,10 @@ public class AccountService {
      */
     @Transactional
     public AccountEntity createAccount(String token, AccountCreateDto.Request request) {
-        // 토큰 유효성 확인
-        if (!tokenProvider.validateToken(token)) {  // 여기서부터 오류 남..ㅠ
-            throw new UserException(TOKEN_EXPIRED);
-        }
-
         // 토큰에서 추출한 사용자와 요청으로 받은 사용자가 동일한지 비교
         Long tokenUserId = tokenProvider.getId(token);
         if (!Objects.equals(request.getUserId(), tokenUserId)) {
-            throw new RuntimeException("요청하신 사용자와 Token 으로 인증된 사용자가 일치하지 않습니다.");
+            throw new RuntimeException("요청하신 사용자와 Token 인증 사용자가 일치하지 않습니다.");
         }
 
         // 맞다면 계좌번호 생성 후 계좌 저장, 저장된 정보 컨트롤러로 넘김

--- a/src/main/java/com/zerobase/BankSSun/service/AccountService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/AccountService.java
@@ -32,12 +32,15 @@ public class AccountService {
             throw new RuntimeException("요청하신 사용자와 Token 인증 사용자가 일치하지 않습니다.");
         }
 
+        String newAccountNumber = makeAccountNumber();
+        String newAccountName = request.getAccountName();
+
         // 맞다면 계좌번호 생성 후 계좌 저장, 저장된 정보 컨트롤러로 넘김
         return accountRepository.save(
             AccountEntity.builder()
                 .userId(request.getUserId())
-                .accountNumber(makeAccountNumber())
-                .accountName("샘플")
+                .accountNumber(newAccountNumber)
+                .accountName(newAccountName == null ? newAccountNumber : newAccountName)
                 .amount(request.getInitialBalance())
                 .isDeleted(false)
                 .build()

--- a/src/main/java/com/zerobase/BankSSun/service/AccountService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/AccountService.java
@@ -1,0 +1,63 @@
+package com.zerobase.BankSSun.service;
+
+import static com.zerobase.BankSSun.type.ErrorCode.USER_NOT_FOUND;
+
+import com.zerobase.BankSSun.domain.entity.AccountEntity;
+import com.zerobase.BankSSun.domain.entity.UserEntity;
+import com.zerobase.BankSSun.domain.repository.AccountRepository;
+import com.zerobase.BankSSun.domain.repository.UserRepository;
+import com.zerobase.BankSSun.dto.AccountCreateDto;
+import com.zerobase.BankSSun.exception.UserException;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 계좌 생성_23.07.31
+     */
+    @Transactional
+    public AccountCreateDto.Response createAccount(Long userId, Long initBalance) {
+        // 1. 사용자가 있는지 조회
+        // 2. 있다면 계좌번호 생성 후 계좌 저장, 저장된 정보를 response dto 에 담아 넘김
+        UserEntity userEntity = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        AccountEntity savedAccount = accountRepository.save(AccountEntity.builder()
+            .userId(userEntity.getId())
+            .accountNumber(makeAccountNumber())
+            .accountName("샘플")
+            .amount(initBalance)
+            .isDeleted(false)
+            .build());
+
+        return AccountCreateDto.Response.builder()
+            .userId(savedAccount.getUserId())
+            .accountNumber(savedAccount.getAccountNumber())
+            .amount(savedAccount.getAmount())
+            .createdAt(savedAccount.getCreatedAt())
+            .build();
+    }
+
+
+    /**
+     * 계좌번호 생성_23.07.31
+     */
+    private String makeAccountNumber() {
+        // 계좌번호 13자리 생성(893-XXXXXX-XXXXX)
+        // 원래 랜덤으로 생성 예정이었는데, 계좌테이블 가장 마지막 정보를 가져오고
+        // 거기서 +1 한 숫자로 생성하는 것도 괜찮은 듯
+        String number = "8934567890123";
+        // 중복 확인
+        if (accountRepository.existsByAccountNumber(number)) { // 계좌번호가 이미 존재하는 경우
+            makeAccountNumber();
+        }
+        return number;
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
@@ -6,9 +6,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    USER_NOT_FOUND("가입되지 않은 사용자입니다."),
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     ALREADY_EXISTS_PHONE("이미 가입된 휴대전화번호입니다."),
-    PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.");
+    PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다."),
+
+    USER_NOT_PERMITTED("사용자 권한이 없습니다."),
+
+    TOKEN_EXPIRED("유효기간이 만료된 토큰입니다. 다시 로그인해주세요.");
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/BankSSun/web/AccountController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AccountController.java
@@ -1,5 +1,7 @@
 package com.zerobase.BankSSun.web;
 
+import static com.zerobase.BankSSun.security.JwtAuthenticationFilter.TOKEN_PREFIX;
+
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.dto.AccountCreateDto;
 import com.zerobase.BankSSun.service.AccountService;
@@ -25,7 +27,7 @@ public class AccountController {
         @RequestHeader(name = "Authorization") String token,
         @RequestBody @Valid AccountCreateDto.Request request
     ) {
-        AccountEntity accountEntity = accountService.createAccount(token, request);
+        AccountEntity accountEntity = accountService.createAccount(token.substring(TOKEN_PREFIX.length()), request);
         return ResponseEntity.ok(
             AccountCreateDto.Response.builder()
                 .userId(accountEntity.getUserId())

--- a/src/main/java/com/zerobase/BankSSun/web/AccountController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AccountController.java
@@ -1,0 +1,31 @@
+package com.zerobase.BankSSun.web;
+
+import com.zerobase.BankSSun.dto.AccountCreateDto;
+import com.zerobase.BankSSun.dto.AccountCreateDto.Response;
+import com.zerobase.BankSSun.service.AccountService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    /**
+     * 계좌 생성_23.07.31
+     */
+    @PostMapping("/account")
+    public ResponseEntity<AccountCreateDto.Response> createAccount(
+        @RequestBody @Valid AccountCreateDto.Request request
+    ) {
+        Response response = accountService.createAccount(
+            request.getUserId(), request.getInitialBalance()
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/web/AccountController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AccountController.java
@@ -1,13 +1,14 @@
 package com.zerobase.BankSSun.web;
 
+import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.dto.AccountCreateDto;
-import com.zerobase.BankSSun.dto.AccountCreateDto.Response;
 import com.zerobase.BankSSun.service.AccountService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,15 +18,21 @@ public class AccountController {
     private final AccountService accountService;
 
     /**
-     * 계좌 생성_23.07.31
+     * 계좌 생성_23.08.01
      */
     @PostMapping("/account")
     public ResponseEntity<AccountCreateDto.Response> createAccount(
+        @RequestHeader(name = "Authorization") String token,
         @RequestBody @Valid AccountCreateDto.Request request
     ) {
-        Response response = accountService.createAccount(
-            request.getUserId(), request.getInitialBalance()
+        AccountEntity accountEntity = accountService.createAccount(token, request);
+        return ResponseEntity.ok(
+            AccountCreateDto.Response.builder()
+                .userId(accountEntity.getUserId())
+                .accountNumber(accountEntity.getAccountNumber())
+                .amount(accountEntity.getAmount())
+                .createdAt(accountEntity.getCreatedAt())
+                .build()
         );
-        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/zerobase/BankSSun/web/AuthController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AuthController.java
@@ -40,12 +40,15 @@ public class AuthController {
 
 
     /**
-     * 로그인 api_23.07.26
+     * 로그인 api_23.08.01
      */
     @PostMapping("/sign-in")
     public ResponseEntity<String> signIn(@RequestBody SignInRequest request) {
         UserEntity user = this.userService.authenticate(request);
-        String token = this.tokenProvider.generateToken(user.getPhone(), user.getRole());
+        String token = this.tokenProvider.generateToken(
+            user.getId(),
+            user.getPhone(),
+            user.getRole());
         return ResponseEntity.ok(token);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,5 +7,5 @@ spring.datasource.password=9336
 #jpa
 spring.jpa.show-sql=true
 spring.jpa.database=mysql
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 계좌 생성 기능 부재

**🌷 TO-BE**
- 계좌 관리와 관련한 AccountEntity, AccountRepository, AccountService, AccountController 생성
- 계좌 생성과 관련한 AccountCreateDto 생성(이너 클래스로 Request, Response 구분)
- 계좌 생성 api 작성
  - 헤더에 `Authorization`으로 토큰을 받고, 계좌 생성 요청 dto 클래스(사용자 아이디, 계좌별칭(선택), 초기금액)를 받아 service로 넘김
  - 요청 dto에서 보내는 userId와 토큰에서 추출한 userId가 같으면 계좌번호 생성 후 db에 저장
  - 계좌번호는 11~13자리의 번호를 등록 가능한데 초기번호인 873-0000-0000에서 시작해 +1씩 증가하는 방식으로 생성
  - 계좌별칭을 null로 보내거나 아예 보내지 않으면 생성된 계좌번호를 별칭으로 임시지정

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 **=> 추후 추가 예정**
- [x] API 테스트 

---
### 🗣️ Comment
- PR을 작성하다보니 생각난 부분인데, 계좌번호 생성 시 중복 확인하는 로직이 빠짐.
랜덤 생성이 아닌 번호순이기 때문에 생성만 하면 중복확인을 할 필요가 없는데, 
타 은행의 계좌번호를 등록하는 기능도 있기 때문에 중복확인 로직 추가할 예정.