### PR TITLE
Refactor: UserException 클래스명 변경, 계좌 생성 시 에러를 CustomException으로 표시

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/exception/CustomException.java
+++ b/src/main/java/com/zerobase/BankSSun/exception/CustomException.java
@@ -12,12 +12,12 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class UserException extends RuntimeException {
+public class CustomException extends RuntimeException {
 
     private ErrorCode errorCode;
     private String errorMessage;
 
-    public UserException(ErrorCode errorCode) {
+    public CustomException(ErrorCode errorCode) {
         this.errorCode = errorCode;
         this.errorMessage = errorCode.getDescription();
     }

--- a/src/main/java/com/zerobase/BankSSun/service/AccountService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/AccountService.java
@@ -1,9 +1,12 @@
 package com.zerobase.BankSSun.service;
 
+import static com.zerobase.BankSSun.type.ErrorCode.TOKEN_NOT_MATCH_USER;
+
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.domain.repository.AccountRepository;
 import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.AccountCreateDto;
+import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.security.TokenProvider;
 import java.util.Objects;
 import javax.transaction.Transactional;
@@ -29,7 +32,7 @@ public class AccountService {
         // 토큰에서 추출한 사용자와 요청으로 받은 사용자가 동일한지 비교
         Long tokenUserId = tokenProvider.getId(token);
         if (!Objects.equals(request.getUserId(), tokenUserId)) {
-            throw new RuntimeException("요청하신 사용자와 Token 인증 사용자가 일치하지 않습니다.");
+            throw new CustomException(TOKEN_NOT_MATCH_USER);
         }
 
         String newAccountNumber = makeAccountNumber();

--- a/src/main/java/com/zerobase/BankSSun/service/UserService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/UserService.java
@@ -6,7 +6,7 @@ import com.zerobase.BankSSun.domain.entity.UserEntity;
 import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.SignInRequest;
 import com.zerobase.BankSSun.dto.SignUpDto.SignUpRequest;
-import com.zerobase.BankSSun.exception.UserException;
+import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.type.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +39,7 @@ public class UserService implements UserDetailsService {
     public UserEntity signUp(SignUpRequest user) {
         boolean exists = this.userRepository.existsByPhone(user.getPhone());
         if (exists) {
-            throw new UserException(ALREADY_EXISTS_PHONE);
+            throw new CustomException(ALREADY_EXISTS_PHONE);
         }
 
         user.setPassword(this.passwordEncoder.encode(user.getPassword()));
@@ -51,10 +51,10 @@ public class UserService implements UserDetailsService {
      */
     public UserEntity authenticate(SignInRequest user) {
         UserEntity userEntity = this.userRepository.findByPhone(user.getPhone())
-            .orElseThrow(() -> new UserException(ALREADY_EXISTS_PHONE));
+            .orElseThrow(() -> new CustomException(ALREADY_EXISTS_PHONE));
 
         if (!this.passwordEncoder.matches(user.getPassword(), userEntity.getPassword())) {
-            throw new UserException(ErrorCode.PASSWORD_NOT_MATCH);
+            throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
         }
 
         return userEntity;

--- a/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
 
     USER_NOT_PERMITTED("사용자 권한이 없습니다."),
 
-    TOKEN_EXPIRED("유효기간이 만료된 토큰입니다. 다시 로그인해주세요.");
+    TOKEN_EXPIRED("유효기간이 만료된 토큰입니다. 다시 로그인해주세요."),
+    TOKEN_NOT_MATCH_USER("요청하신 사용자와 Token 인증 사용자가 일치하지 않습니다.");
 
     private final String description;
 }


### PR DESCRIPTION

### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 계좌 생성 시 토큰에서 추출한 사용자와 request body로 전달받는 사용자가 다를 경우
RuntimeException으로 예외 발생
- UserException이 프로젝트 전반적으로 사용되는 커스텀익셉션인데 이름이 UserException이라고 되어있어
용도가 헷갈릴 수 있음

**🌷 TO-BE**
- 이 예외 상황에 대한 에러메세지도 ErrorCode에 정의한 후 사용
- UserException -> CustomException으로 클래스명 변경

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 **=> 이 부분에 대한 테스트코드가 아직 없어서 확인 안함**
- [x] API 테스트 