### PR TITLE
Fix: 계좌 생성 시 SSun 은행으로 생성되도록 수정

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
@@ -36,7 +36,7 @@ public class AccountEntity extends BaseEntity {
     @NotNull
     private Long userId;
 
-    @NotBlank(message = "은행 이름은 필수값입니다.")
+    @NotNull
     @Enumerated(EnumType.STRING)
     private Bank bank;
 

--- a/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
@@ -1,11 +1,15 @@
 package com.zerobase.BankSSun.domain.entity;
 
+import com.zerobase.BankSSun.type.Bank;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,6 +35,10 @@ public class AccountEntity extends BaseEntity {
 
     @NotNull
     private Long userId;
+
+    @NotBlank(message = "은행 이름은 필수값입니다.")
+    @Enumerated(EnumType.STRING)
+    private Bank bank;
 
     @NotNull
     private String accountNumber;

--- a/src/main/java/com/zerobase/BankSSun/service/AccountService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/AccountService.java
@@ -11,6 +11,7 @@ import com.zerobase.BankSSun.dto.AccountCreateDto;
 import com.zerobase.BankSSun.dto.AccountDeleteRequest;
 import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.security.TokenProvider;
+import com.zerobase.BankSSun.type.Bank;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.transaction.Transactional;
@@ -28,7 +29,7 @@ public class AccountService {
     private final TokenProvider tokenProvider;
 
     /**
-     * 계좌 생성_23.08.01
+     * 계좌 생성(SSun 은행)_23.08.02
      */
     @Transactional
     public AccountEntity createAccount(String token, AccountCreateDto.Request request) {
@@ -45,6 +46,7 @@ public class AccountService {
         return accountRepository.save(
             AccountEntity.builder()
                 .userId(request.getUserId())
+                .bank(Bank.SSun)
                 .accountNumber(newAccountNumber)
                 .accountName(newAccountName == null ? newAccountNumber : newAccountName)
                 .amount(request.getInitialBalance())

--- a/src/main/java/com/zerobase/BankSSun/type/Bank.java
+++ b/src/main/java/com/zerobase/BankSSun/type/Bank.java
@@ -1,0 +1,9 @@
+package com.zerobase.BankSSun.type;
+
+public enum Bank {
+    SSun,
+    Wind,
+    Rain,
+    Cloud,
+    Snow
+}


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- AccountEntity에 은행명 컬럼이 존재하지 않았음.
- 계좌 생성 시 은행이 지정되지 않았음.

**🌷 TO-BE**
- AccountEntity에 은행명 추가(Enum으로 은행명 추가)
- 계좌 생성 시 SSun 은행으로 생성되도록 수정(타 은행은 생성은 불가능하고 등록만 가능함)
아직 등록 기능은 없음

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 **=> 추가 예정**
- [x] API 테스트 