### PR TITLE
Feat: 송금 api 완성

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
@@ -9,7 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,6 +47,7 @@ public class AccountEntity extends BaseEntity {
     private String accountName;
 
     @NotNull
+    @Min(value = 0,message = "계좌의 잔액은 0원 이상이어야 합니다.")
     private Long amount;
 
     @NotNull

--- a/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
@@ -40,13 +40,13 @@ public class TransactionEntity {
     @NotNull
     private Long amount;
 
-    private String depositName;
+    private String depositName; // 입금자명
 
-    private String withdrawName;
+    private String withdrawName; // 출금자명
 
-    private String receivedName;
+    private String receivedName; // 송금받는 계좌주명
 
-    private String receivedAccount;
+    private String receivedAccount; // 송금받는 계좌번호
 
     @CreatedDate
     private LocalDateTime transactedAt;

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/RemittanceDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/RemittanceDto.java
@@ -1,0 +1,40 @@
+package com.zerobase.BankSSun.dto.transaction;
+
+import com.zerobase.BankSSun.type.Bank;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+public class RemittanceDto {
+
+    @Getter
+    public static class Request {
+
+        @NotBlank(message = "보내는 계좌번호는 필수값입니다.")
+        private String sentAccount;
+
+        @NotBlank(message = "받는 계좌번호는 필수값입니다.")
+        private String receivedAccount;
+
+        @NotNull(message = "송금액은 필수값입니다.")
+        @Min(value = 1, message = "송금 최소금액은 1원입니다.")
+        private Long amount;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+
+        private String sentAccount;
+
+        private String receivedAccount;
+
+        private Bank receivedBank;
+
+        private String receivedName;
+
+        private Long amount;
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -2,13 +2,19 @@ package com.zerobase.BankSSun.service;
 
 import static com.zerobase.BankSSun.type.ErrorCode.ACCOUNT_NOT_FOUND;
 import static com.zerobase.BankSSun.type.ErrorCode.BALANCE_NOT_ENOUGH;
+import static com.zerobase.BankSSun.type.ErrorCode.RECEIVED_ACCOUNT_NOT_FOUND;
+import static com.zerobase.BankSSun.type.ErrorCode.SENT_ACCOUNT_NOT_FOUND;
 import static com.zerobase.BankSSun.type.ErrorCode.TOKEN_NOT_MATCH_USER;
+import static com.zerobase.BankSSun.type.ErrorCode.USER_NOT_FOUND;
 
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.domain.entity.TransactionEntity;
+import com.zerobase.BankSSun.domain.entity.UserEntity;
 import com.zerobase.BankSSun.domain.repository.AccountRepository;
 import com.zerobase.BankSSun.domain.repository.TransactionRepository;
+import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.transaction.DepositDto;
+import com.zerobase.BankSSun.dto.transaction.RemittanceDto;
 import com.zerobase.BankSSun.dto.transaction.WithdrawDto;
 import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.security.TokenProvider;
@@ -27,6 +33,7 @@ public class TransactionService {
 
     private final AccountRepository accountRepository;
     private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
 
     private final TokenProvider tokenProvider;
 
@@ -110,4 +117,66 @@ public class TransactionService {
             .transacted_at(LocalDateTime.now())
             .build();
     }
+
+    /**
+     * 송금_23.08.02
+     */
+    @Transactional
+    public RemittanceDto.Response remittance(String token, RemittanceDto.Request request) {
+        AccountEntity sentAccountEntity = accountRepository.findByAccountNumber(
+                request.getSentAccount())
+            .orElseThrow(() -> new CustomException(SENT_ACCOUNT_NOT_FOUND));
+
+        AccountEntity recievedAccountEntity = accountRepository.findByAccountNumber(
+                request.getReceivedAccount())
+            .orElseThrow(() -> new CustomException(RECEIVED_ACCOUNT_NOT_FOUND));
+
+        UserEntity recievedUserEntity = userRepository.findById(recievedAccountEntity.getUserId())
+            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 토큰의 사용자와 보내는 계좌의 사용자 확인
+        Long tokenUserId = tokenProvider.getId(token);
+
+        if (!Objects.equals(tokenUserId, sentAccountEntity.getUserId())) {
+            throw new CustomException(TOKEN_NOT_MATCH_USER);
+        }
+
+        // 보내는 계좌와 받는 계좌 존재/삭제 여부 확인
+        if (sentAccountEntity.getIsDeleted()) {
+            throw new CustomException(SENT_ACCOUNT_NOT_FOUND);
+        } else if (recievedAccountEntity.getIsDeleted()) {
+            throw new CustomException(RECEIVED_ACCOUNT_NOT_FOUND);
+        }
+
+        // (송금 요청 금액 > 보내는 계좌의 잔액)의 경우 예외 발생
+        if (request.getAmount() > sentAccountEntity.getAmount()) {
+            throw new CustomException(BALANCE_NOT_ENOUGH);
+        }
+
+        // 보내는 계좌, 받는 계좌의 잔액 변경
+        sentAccountEntity.setAmount(sentAccountEntity.getAmount() - request.getAmount());
+        recievedAccountEntity.setAmount(recievedAccountEntity.getAmount() + request.getAmount());
+
+        // 거래 테이블에 거래 저장
+        transactionRepository.save(
+            TransactionEntity.builder()
+                .accountId(sentAccountEntity.getId())
+                .transaction_type(Transaction.REMITTANCE)
+                .amount(request.getAmount())
+                .receivedName(recievedUserEntity.getUsername())
+                .receivedAccount(request.getReceivedAccount())
+                .build()
+        );
+
+        return RemittanceDto.Response.builder()
+            .sentAccount(request.getSentAccount())
+            .receivedAccount(request.getReceivedAccount())
+            .receivedBank(recievedAccountEntity.getBank())
+            .receivedName(recievedUserEntity.getUsername())
+            .amount(request.getAmount())
+            .build();
+    }
+
+    // 토큰에서 추출한 사용자와 요청 객체에서 추출한 사용자가 일치한지
+    // 확인하는 private 메소드 만들기!
 }

--- a/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
@@ -16,8 +16,10 @@ public enum ErrorCode {
     TOKEN_NOT_MATCH_USER("요청하신 사용자와 Token 인증 사용자가 일치하지 않습니다."),
 
     ACCOUNT_NOT_FOUND("계좌를 찾을 수 없습니다."),
+    SENT_ACCOUNT_NOT_FOUND("송금 보내는 계좌를 찾을 수 없습니다."),
+    RECEIVED_ACCOUNT_NOT_FOUND("송금 받는 계좌를 찾을 수 없습니다."),
     ACCOUNT_NOT_EMPTY("계좌에 잔액이 남아있습니다."),
-    BALANCE_NOT_ENOUGH("계좌의 잔액이 부족합니다.")
+    BALANCE_NOT_ENOUGH("계좌의 잔액이 부족합니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/BankSSun/web/TransactionController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/TransactionController.java
@@ -3,6 +3,7 @@ package com.zerobase.BankSSun.web;
 import static com.zerobase.BankSSun.security.JwtAuthenticationFilter.TOKEN_PREFIX;
 
 import com.zerobase.BankSSun.dto.transaction.DepositDto;
+import com.zerobase.BankSSun.dto.transaction.RemittanceDto;
 import com.zerobase.BankSSun.dto.transaction.WithdrawDto;
 import com.zerobase.BankSSun.service.TransactionService;
 import javax.validation.Valid;
@@ -43,5 +44,18 @@ public class TransactionController {
         WithdrawDto.Response response = transactionService.withdraw(
             token.substring(TOKEN_PREFIX.length()), request);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 송금_23.08.02
+     */
+    @PutMapping("/remittance")
+    public ResponseEntity<RemittanceDto.Response> remittance(
+        @RequestHeader(name = "Authorization") String token,
+        @RequestBody @Valid RemittanceDto.Request request
+    ) {
+        return ResponseEntity.ok(
+            transactionService.remittance(token.substring(TOKEN_PREFIX.length()), request)
+        );
     }
 }


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 송금 기능 부재

**🌷 TO-BE**
- 송금 기능 완성
   - 헤더에 토큰, 바디에 '송금 보내는 계좌, 송금 받는 계좌, 송금액 '을 받음
   - 토큰의 사용자와 송금 보내는 계좌의 사용자 확인
   - 송금 보내는 계좌와 송금 받는 계좌 존재(삭제) 여부 확인
   - (송금 요청 금액 > 보내는 계좌의 잔액)의 경우 예외 발생
   - 보내는 계좌, 받는 계좌의 잔액 변경
   - 거래 테이블에 거래 추가
- AccountEntity의 amount(잔액) 컬럼에 `@Min` 어노테이션을 추가해 0원 이상이도록 했습니다.

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 **=> 추후 작성 예정**
- [x] API 테스트 

---
### 🗣️Comment
TransactionService.java의 126~136 줄을 보시면 굉장히 복잡한 걸 알 수 있습니다...ㅠㅠ
`@ManyToOne` 으로 계좌와 사용자를 묶어두지 않아서 계좌번호에서 사용자 정보를(사용자 id를 제외한) 가져오려면
조금 복잡하더라구요. 아직 어떻게 테이블간의 의존성을 설정해야하는지 모르겠어서
계좌 테이블에 그냥 사용자 id 만 저장해뒀었는데, 일단 기능들 먼저 구현 후 조금 더 알아보고 테이블끼리 묶는? 식으로 리팩토링 해보겠습니다ㅠㅠ
