### PR TITLE
Fix: 테이블 간 연관관계 @ManyToOne 어노테이션 사용하도록 수정

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/AccountEntity.java
@@ -9,6 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -33,8 +34,8 @@ public class AccountEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Long userId;
+    @ManyToOne
+    private UserEntity user;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -47,7 +48,7 @@ public class AccountEntity extends BaseEntity {
     private String accountName;
 
     @NotNull
-    @Min(value = 0,message = "계좌의 잔액은 0원 이상이어야 합니다.")
+    @Min(value = 0, message = "계좌의 잔액은 0원 이상이어야 합니다.")
     private Long amount;
 
     @NotNull

--- a/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
@@ -10,6 +10,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,11 +33,11 @@ public class TransactionEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Long accountId;
+    @ManyToOne
+    private AccountEntity account;
 
     @Enumerated(EnumType.STRING)
-    private Transaction transaction_type;
+    private Transaction transactionType;
 
     @NotNull
     private Long amount;

--- a/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/entity/TransactionEntity.java
@@ -10,7 +10,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -131,10 +131,6 @@ public class TransactionService {
                 request.getReceivedAccount())
             .orElseThrow(() -> new CustomException(RECEIVED_ACCOUNT_NOT_FOUND));
 
-        UserEntity recievedUserEntity = userRepository.findById(
-                recievedAccountEntity.getUser().getId())
-            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
         // 토큰의 사용자와 보내는 계좌의 사용자 확인
         Long tokenUserId = tokenProvider.getId(token);
 
@@ -164,7 +160,7 @@ public class TransactionService {
                 .account(sentAccountEntity)
                 .transactionType(Transaction.REMITTANCE)
                 .amount(request.getAmount())
-                .receivedName(recievedUserEntity.getUsername())
+                .receivedName(recievedAccountEntity.getUser().getUsername())
                 .receivedAccount(request.getReceivedAccount())
                 .build()
         );
@@ -173,7 +169,7 @@ public class TransactionService {
             .sentAccount(request.getSentAccount())
             .receivedAccount(request.getReceivedAccount())
             .receivedBank(recievedAccountEntity.getBank())
-            .receivedName(recievedUserEntity.getUsername())
+            .receivedName(recievedAccountEntity.getUser().getUsername())
             .amount(request.getAmount())
             .build();
     }

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -57,8 +57,8 @@ public class TransactionService {
         // 거래 내역 테이블에 거래추가
         transactionRepository.save(
             TransactionEntity.builder()
-                .accountId(accountEntity.getId())
-                .transaction_type(Transaction.DEPOSIT)
+                .account(accountEntity)
+                .transactionType(Transaction.DEPOSIT)
                 .amount(request.getAmount())
                 .depositName(request.getDepositName())
                 .build()
@@ -88,7 +88,7 @@ public class TransactionService {
         }
 
         // 토큰의 사용자와 출금 요청 계좌의 소유주 일치 여부 확인
-        if (!Objects.equals(tokenUserId, accountEntity.getUserId())) {
+        if (!Objects.equals(tokenUserId, accountEntity.getUser().getId())) {
             throw new CustomException(TOKEN_NOT_MATCH_USER);
         }
 
@@ -103,8 +103,8 @@ public class TransactionService {
         // 거래 내역 테이블에 거래 추가
         transactionRepository.save(
             TransactionEntity.builder()
-                .accountId(accountEntity.getId())
-                .transaction_type(Transaction.WITHDRAW)
+                .account(accountEntity)
+                .transactionType(Transaction.WITHDRAW)
                 .amount(request.getAmount())
                 .depositName(request.getWithdrawName())
                 .build()
@@ -131,13 +131,14 @@ public class TransactionService {
                 request.getReceivedAccount())
             .orElseThrow(() -> new CustomException(RECEIVED_ACCOUNT_NOT_FOUND));
 
-        UserEntity recievedUserEntity = userRepository.findById(recievedAccountEntity.getUserId())
+        UserEntity recievedUserEntity = userRepository.findById(
+                recievedAccountEntity.getUser().getId())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 토큰의 사용자와 보내는 계좌의 사용자 확인
         Long tokenUserId = tokenProvider.getId(token);
 
-        if (!Objects.equals(tokenUserId, sentAccountEntity.getUserId())) {
+        if (!Objects.equals(tokenUserId, sentAccountEntity.getUser().getId())) {
             throw new CustomException(TOKEN_NOT_MATCH_USER);
         }
 
@@ -160,8 +161,8 @@ public class TransactionService {
         // 거래 테이블에 거래 저장
         transactionRepository.save(
             TransactionEntity.builder()
-                .accountId(sentAccountEntity.getId())
-                .transaction_type(Transaction.REMITTANCE)
+                .account(sentAccountEntity)
+                .transactionType(Transaction.REMITTANCE)
                 .amount(request.getAmount())
                 .receivedName(recievedUserEntity.getUsername())
                 .receivedAccount(request.getReceivedAccount())

--- a/src/main/java/com/zerobase/BankSSun/web/AccountController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/AccountController.java
@@ -33,7 +33,7 @@ public class AccountController {
             token.substring(TOKEN_PREFIX.length()), request);
         return ResponseEntity.ok(
             AccountCreateDto.Response.builder()
-                .userId(accountEntity.getUserId())
+                .userId(accountEntity.getUser().getId())
                 .accountNumber(accountEntity.getAccountNumber())
                 .amount(accountEntity.getAmount())
                 .createdAt(accountEntity.getCreatedAt())


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- user - account , account - transaction 테이블의 연관관계를 단순 id로만 연결해서
연관된 정보를 찾을 때 로직이 불필요하게 길어지는 현상이 있었음.
  - 예시)
  - accountNumber를 아는 상황에서 해당 계좌 소유주의 이름을 불러오려고 할 때,
  userRepository에서 사용자 id 를 이용해 데이터를 찾은 후 이름을 가져와야 함.

**🌷 TO-BE**
- `@ManyToOne` 어노테이션을 사용해 테이블의 연관관계를 매핑해 필요한 정보를 간단하게 가져올 수 있음.
- 수정과정에서 거래 테이블의 transactionType 변수명 컨벤션이 맞지 않는 것을 발견해(transaction_type으로 되어있었음) 수정함.
- 연관관계 변경으로 인해 불필요해진 로직 삭제

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

#36 