### PR TITLE
Feat: 거래 내역 조회 api 완성

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/domain/repository/TransactionRepository.java
+++ b/src/main/java/com/zerobase/BankSSun/domain/repository/TransactionRepository.java
@@ -1,10 +1,16 @@
 package com.zerobase.BankSSun.domain.repository;
 
 import com.zerobase.BankSSun.domain.entity.TransactionEntity;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<TransactionEntity, Long> {
 
+    // 계좌 id, 조회 기간을 정해서 가져오는 것
+    List<TransactionEntity> findByAccountIdAndTransactedAtBetween(
+        Long accountId, LocalDateTime startDate, LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionDto.java
@@ -1,5 +1,7 @@
 package com.zerobase.BankSSun.dto.transaction;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.zerobase.BankSSun.type.Transaction;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -17,5 +19,6 @@ public class TransactionDto {
 
     private Transaction type;
 
+    @JsonFormat(shape = Shape.STRING,  pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime transactedAt;
 }

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionDto.java
@@ -1,4 +1,4 @@
-package com.zerobase.BankSSun.vo;
+package com.zerobase.BankSSun.dto.transaction;
 
 import com.zerobase.BankSSun.type.Transaction;
 import java.time.LocalDateTime;
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class TransactionVo {
+public class TransactionDto {
 
     private Long id;
 

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
@@ -1,0 +1,34 @@
+package com.zerobase.BankSSun.dto.transaction;
+
+import com.zerobase.BankSSun.vo.TransactionVo;
+import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+public class TransactionListDto {
+
+    @Getter
+    public static class Request {
+
+        @NotNull
+        @Min(1)
+        private Long accountId;         // 거래 내역을 조회할 계좌 id
+
+        @NotBlank(message = "계좌번호는 필수값입니다.")
+        private String accountNumber;   // 거래 내역의 조회할 계좌번호
+
+        private String startDate;       // 조회 시작 날짜
+
+        private String endDate;         // 조회 마지막 날짜
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+
+        private List<TransactionVo> transactionList;
+    }
+}

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
@@ -1,6 +1,5 @@
 package com.zerobase.BankSSun.dto.transaction;
 
-import com.zerobase.BankSSun.vo.TransactionVo;
 import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -29,6 +28,6 @@ public class TransactionListDto {
     @Builder
     public static class Response {
 
-        private List<TransactionVo> transactionList;
+        private List<TransactionDto> transactionList;
     }
 }

--- a/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
+++ b/src/main/java/com/zerobase/BankSSun/dto/transaction/TransactionListDto.java
@@ -1,5 +1,8 @@
 package com.zerobase.BankSSun.dto.transaction;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -14,14 +17,16 @@ public class TransactionListDto {
 
         @NotNull
         @Min(1)
-        private Long accountId;         // 거래 내역을 조회할 계좌 id
+        private Long accountId;             // 거래 내역을 조회할 계좌 id
 
         @NotBlank(message = "계좌번호는 필수값입니다.")
-        private String accountNumber;   // 거래 내역의 조회할 계좌번호
+        private String accountNumber;       // 거래 내역의 조회할 계좌번호
 
-        private String startDate;       // 조회 시작 날짜
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate startDate;    // 조회 시작 날짜
 
-        private String endDate;         // 조회 마지막 날짜
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate endDate;      // 조회 마지막 날짜
     }
 
     @Getter

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -2,24 +2,32 @@ package com.zerobase.BankSSun.service;
 
 import static com.zerobase.BankSSun.type.ErrorCode.ACCOUNT_NOT_FOUND;
 import static com.zerobase.BankSSun.type.ErrorCode.BALANCE_NOT_ENOUGH;
+import static com.zerobase.BankSSun.type.ErrorCode.INVALID_DATE;
+import static com.zerobase.BankSSun.type.ErrorCode.INVALID_DATE_RANGE;
+import static com.zerobase.BankSSun.type.ErrorCode.NOT_EQUAL_ID_AND_ACCOUNT_NUMBER;
 import static com.zerobase.BankSSun.type.ErrorCode.RECEIVED_ACCOUNT_NOT_FOUND;
 import static com.zerobase.BankSSun.type.ErrorCode.SENT_ACCOUNT_NOT_FOUND;
 import static com.zerobase.BankSSun.type.ErrorCode.TOKEN_NOT_MATCH_USER;
-import static com.zerobase.BankSSun.type.ErrorCode.USER_NOT_FOUND;
 
 import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.domain.entity.TransactionEntity;
-import com.zerobase.BankSSun.domain.entity.UserEntity;
 import com.zerobase.BankSSun.domain.repository.AccountRepository;
 import com.zerobase.BankSSun.domain.repository.TransactionRepository;
 import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.transaction.DepositDto;
 import com.zerobase.BankSSun.dto.transaction.RemittanceDto;
+import com.zerobase.BankSSun.dto.transaction.TransactionListDto;
 import com.zerobase.BankSSun.dto.transaction.WithdrawDto;
 import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.security.TokenProvider;
+import com.zerobase.BankSSun.type.ErrorCode;
 import com.zerobase.BankSSun.type.Transaction;
+import com.zerobase.BankSSun.vo.TransactionVo;
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +41,6 @@ public class TransactionService {
 
     private final AccountRepository accountRepository;
     private final TransactionRepository transactionRepository;
-    private final UserRepository userRepository;
 
     private final TokenProvider tokenProvider;
 
@@ -174,6 +181,155 @@ public class TransactionService {
             .build();
     }
 
+    /**
+     * 거래 내역 조회_23.08.03
+     *
+     * @apiNote 삭제된 계좌는 거래 내역 조회 불가
+     * @apiNote 삭제되지 않은 계좌의 거래 내역에 포함된 삭제된 계좌와의 거래는 표시
+     */
+    @Transactional
+    public TransactionListDto.Response getTransactionList
+    (
+        String token, TransactionListDto.Request request
+    ) {
+        // 조회 계좌 존재/삭제 여부 확인
+        AccountEntity accountEntity = getValidAccountEntity(request.getAccountNumber());
+
+        // 토큰의 사용자 id와 거래내역을 조회할 계좌의 userId 확인
+        if (!Objects.equals(tokenProvider.getId(token), accountEntity.getUser().getId())) {
+            throw new CustomException(TOKEN_NOT_MATCH_USER);
+        }
+
+        // 계좌 id 와 계좌번호의 계좌 id 일치 여부 확인
+        TransactionEntity transactionEntity = transactionRepository.findById(request.getAccountId())
+            .orElseThrow(() -> new CustomException(ACCOUNT_NOT_FOUND));
+        if (!request.getAccountNumber().equals(transactionEntity.getAccount().getAccountNumber())) {
+            throw new CustomException(NOT_EQUAL_ID_AND_ACCOUNT_NUMBER);
+        }
+
+        // 올바르게 요청된 날짜 형식: "yyyy-MM-dd"
+        int DATE_FORMAT_LENGTH = ("yyyy-MM-dd").length();
+        String startDateStr = request.getStartDate();
+        String endDateStr = request.getEndDate();
+        String nowDateStr = LocalDateTime.now().toString().substring(0, DATE_FORMAT_LENGTH);
+        int defaultDateRange = 7;
+        int maxDateRange = 7;
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        // 시작 날짜와 끝 날짜가 null 인 경우 (조회일 포함 일주일 내역 반환)
+        if (startDateStr == null && endDateStr == null) {
+            LocalDateTime nowDateTime = LocalDateTime.now();
+            String weekAgoStr = nowDateTime.minusDays(defaultDateRange - 1).toString()
+                .substring(0, DATE_FORMAT_LENGTH);
+
+            LocalDateTime weekAgoDateTime = LocalDateTime.parse(
+                String.format("%s 00:00:00", weekAgoStr), formatter
+            );
+
+            return getTransactionListResponse(request.getAccountId(), weekAgoDateTime, nowDateTime);
+        }
+
+        // 시작 날짜와 끝 날짜 둘 중 하나라도 null 로 보낸 경우
+        if (startDateStr == null || endDateStr == null) {
+            throw new CustomException(INVALID_DATE);
+        }
+
+        // ======== 이 아래로는 두 날짜 다 null 이 아닌 경우들 ========
+
+        LocalDateTime startDateTime;
+        LocalDateTime endDateTime;
+
+        // 두 날짜 중 하나라도 유효하지 않은 날짜(형식)인 경우 ex. 2023-00-44, 230101, 20230808, 23-08-08...
+        try {
+            startDateTime = LocalDateTime.parse(
+                String.format("%s 00:00:00", startDateStr), formatter);
+            endDateTime = LocalDateTime.parse(
+                String.format("%s 23:59:59", endDateStr), formatter);
+        } catch (DateTimeException e) {
+            throw new CustomException(INVALID_DATE);
+        }
+
+        // 끝 날짜가 시작 날짜를 초과한 경우
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new CustomException(INVALID_DATE);
+        }
+
+        // 끝 날짜가 조회 당일 날짜를 초과한 경우
+        LocalDateTime todayDateTime = LocalDateTime.parse(
+            String.format("%s 23:59:59", nowDateStr), formatter
+        );
+        if (endDateTime.isAfter(todayDateTime)) {
+            throw new CustomException(INVALID_DATE);
+        }
+
+        // 조회 기간이 최대 조회 기간을 넘을 경우
+        int betweenDays = Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate())
+            .getDays();
+        if (betweenDays + 1 > maxDateRange) {
+            throw new CustomException(INVALID_DATE_RANGE);
+        }
+
+        // 두 날짜 전부 제대로 조회한 경우
+        return getTransactionListResponse(request.getAccountId(), startDateTime, endDateTime);
+    }
+
     // 토큰에서 추출한 사용자와 요청 객체에서 추출한 사용자가 일치한지
     // 확인하는 private 메소드 만들기!
+
+    /**
+     * 계좌 존재/삭제 여부 확인_23.08.03
+     */
+    private AccountEntity getValidAccountEntity(String accountNumber) {
+        AccountEntity accountEntity = accountRepository.findByAccountNumber(accountNumber)
+            .orElseThrow(() -> new CustomException(ACCOUNT_NOT_FOUND));
+
+        if (accountEntity.getIsDeleted()) {
+            throw new CustomException(ACCOUNT_NOT_FOUND);
+        }
+        return accountEntity;
+    }
+
+    /**
+     * 거래 종류에 따라 거래 대상자 이름 반환_23.08.03
+     *
+     * @implNote 반환되는 이름 종류: 출금자명, 입금자명, 송금 받은 계좌 소유주명
+     */
+    private String getTransactionTargetName(TransactionEntity transaction) {
+        switch (transaction.getTransactionType()) {
+            case WITHDRAW -> {
+                return transaction.getWithdrawName();
+            }
+            case DEPOSIT -> {
+                return transaction.getDepositName();
+            }
+            case REMITTANCE -> {
+                return transaction.getReceivedName();
+            }
+        }
+        return ErrorCode.TRANSACTION_TYPE_NOT_FOUND.getDescription();
+    }
+
+    /**
+     * 거래 내역 조회 Response Dto 반환_23.08.03
+     */
+    private TransactionListDto.Response getTransactionListResponse(
+        Long accountId, LocalDateTime startDateTime, LocalDateTime endDateTime
+    ) {
+        List<TransactionEntity> resultList = transactionRepository.findByAccountIdAndTransactedAtBetween(
+            accountId, startDateTime, endDateTime
+        );
+        return TransactionListDto.Response.builder()
+            .transactionList(resultList.stream()
+                .map(transaction ->
+                    TransactionVo.builder()
+                        .id(transaction.getId())
+                        .transactionTargetName(getTransactionTargetName(transaction))
+                        .amount(transaction.getAmount())
+                        .type(transaction.getTransactionType())
+                        .transactedAt(transaction.getTransactedAt())
+                        .build()
+                ).toList())
+            .build();
+    }
 }

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -294,6 +294,7 @@ public class TransactionService {
      * 거래 종류에 따라 거래 대상자 이름 반환_23.08.03
      *
      * @implNote 반환되는 이름 종류: 출금자명, 입금자명, 송금 받은 계좌 소유주명
+     * @implNote getTransactionList 에서만 사용
      */
     private String getTransactionTargetName(TransactionEntity transaction) {
         switch (transaction.getTransactionType()) {
@@ -312,6 +313,8 @@ public class TransactionService {
 
     /**
      * 거래 내역 조회 Response Dto 반환_23.08.03
+     *
+     * @implNote getTransactionList 에서만 사용
      */
     private TransactionListDto.Response getTransactionListResponse(
         Long accountId, LocalDateTime startDateTime, LocalDateTime endDateTime

--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -13,16 +13,15 @@ import com.zerobase.BankSSun.domain.entity.AccountEntity;
 import com.zerobase.BankSSun.domain.entity.TransactionEntity;
 import com.zerobase.BankSSun.domain.repository.AccountRepository;
 import com.zerobase.BankSSun.domain.repository.TransactionRepository;
-import com.zerobase.BankSSun.domain.repository.UserRepository;
 import com.zerobase.BankSSun.dto.transaction.DepositDto;
 import com.zerobase.BankSSun.dto.transaction.RemittanceDto;
+import com.zerobase.BankSSun.dto.transaction.TransactionDto;
 import com.zerobase.BankSSun.dto.transaction.TransactionListDto;
 import com.zerobase.BankSSun.dto.transaction.WithdrawDto;
 import com.zerobase.BankSSun.exception.CustomException;
 import com.zerobase.BankSSun.security.TokenProvider;
 import com.zerobase.BankSSun.type.ErrorCode;
 import com.zerobase.BankSSun.type.Transaction;
-import com.zerobase.BankSSun.vo.TransactionVo;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -325,7 +324,7 @@ public class TransactionService {
         return TransactionListDto.Response.builder()
             .transactionList(resultList.stream()
                 .map(transaction ->
-                    TransactionVo.builder()
+                    TransactionDto.builder()
                         .id(transaction.getId())
                         .transactionTargetName(getTransactionTargetName(transaction))
                         .amount(transaction.getAmount())

--- a/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/BankSSun/type/ErrorCode.java
@@ -20,6 +20,11 @@ public enum ErrorCode {
     RECEIVED_ACCOUNT_NOT_FOUND("송금 받는 계좌를 찾을 수 없습니다."),
     ACCOUNT_NOT_EMPTY("계좌에 잔액이 남아있습니다."),
     BALANCE_NOT_ENOUGH("계좌의 잔액이 부족합니다."),
+    TRANSACTION_TYPE_NOT_FOUND("거래 종류를 확인할 수 없습니다."),
+
+    INVALID_DATE("유효한 날짜인지 확인해주세요."),
+    INVALID_DATE_RANGE("거래 내역은 최대 일주일까지 조회할 수 있습니다."),
+    NOT_EQUAL_ID_AND_ACCOUNT_NUMBER("accountId 와 accountNumber 의 계좌 id가 일치하지 않습니다."),
     ;
 
     private final String description;

--- a/src/main/java/com/zerobase/BankSSun/vo/TransactionVo.java
+++ b/src/main/java/com/zerobase/BankSSun/vo/TransactionVo.java
@@ -1,0 +1,21 @@
+package com.zerobase.BankSSun.vo;
+
+import com.zerobase.BankSSun.type.Transaction;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TransactionVo {
+
+    private Long id;
+
+    private String transactionTargetName;
+
+    private Long amount;
+
+    private Transaction type;
+
+    private LocalDateTime transactedAt;
+}

--- a/src/main/java/com/zerobase/BankSSun/web/TransactionController.java
+++ b/src/main/java/com/zerobase/BankSSun/web/TransactionController.java
@@ -4,12 +4,15 @@ import static com.zerobase.BankSSun.security.JwtAuthenticationFilter.TOKEN_PREFI
 
 import com.zerobase.BankSSun.dto.transaction.DepositDto;
 import com.zerobase.BankSSun.dto.transaction.RemittanceDto;
+import com.zerobase.BankSSun.dto.transaction.TransactionListDto;
 import com.zerobase.BankSSun.dto.transaction.WithdrawDto;
 import com.zerobase.BankSSun.service.TransactionService;
+import java.text.ParseException;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -56,6 +59,23 @@ public class TransactionController {
     ) {
         return ResponseEntity.ok(
             transactionService.remittance(token.substring(TOKEN_PREFIX.length()), request)
+        );
+    }
+
+    /**
+     * 거래 내역 조회_23.08.03
+     *
+     * @return 최소 하루 ~ 최대 일주일의 거래 내역
+     * @apiNote 시작 날짜, 끝 날짜 둘 다 null 로 보낼 경우 조회일 포함 일주일 내역 반환
+     * @apiNote 날짜 포맷 : yyyy-MM-dd
+     */
+    @GetMapping("/transaction-list")
+    public ResponseEntity<TransactionListDto.Response> getTransactionList(
+        @RequestHeader(name = "Authorization") String token,
+        @RequestBody @Valid TransactionListDto.Request request
+    ) {
+        return ResponseEntity.ok(
+            transactionService.getTransactionList(token.substring(TOKEN_PREFIX.length()), request)
         );
     }
 }


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- #43 이슈 관련 pr 
- 거래 내역 조회 기능 부재

**🌷 TO-BE**
- 거래 내역 조회 api 완성
   - 계좌별로 거래 내역 조회 가능
   - 시작, 끝 날짜가 둘다 null 이면 조회일 포함 일주일간의 내역 반환
   - 예외 발생 상황
      - 요청 객체로 보낸 accountId와 accountNumber의 계좌 id가 다른 경우
      - 본인의 계좌가 아닌 계좌의 내역을 조회하는 경우
      - 아예 존재하지 않거나 삭제된 계좌의 내역을 조회하는 경우
      - 날짜의 형식이 틀렸거나, 두 날짜 중 하나만 null일 경우
      - 시작 날짜가 끝 날짜보다 뒤인 경우
      - 끝 날짜가 조회일보다 뒤인 경우
      - 조회기간이 최대 기간을 넘은 경우(현재 일주일로 설정)
- 사용자는 거래 내역을 List로 받는다. 그 리스트는 TransactionVo 객체를 담고있다.

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 **=> 추후 작업 예정..**
- [x] API 테스트 
