### PR TITLE
Fix: 현금 출금 시 출금자명 null로 저장되던 버그 해결

### DIFF
--- a/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
+++ b/src/main/java/com/zerobase/BankSSun/service/TransactionService.java
@@ -79,7 +79,7 @@ public class TransactionService {
     }
 
     /**
-     * 현금 출금_23.08.02
+     * 현금 출금_23.08.14
      */
     @Transactional
     public WithdrawDto.Response withdraw(String token, WithdrawDto.Request request) {
@@ -112,7 +112,7 @@ public class TransactionService {
                 .account(accountEntity)
                 .transactionType(Transaction.WITHDRAW)
                 .amount(request.getAmount())
-                .depositName(request.getWithdrawName())
+                .withdrawName(request.getWithdrawName())
                 .build()
         );
 


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 현금 출금 시 정상적으로 거래가 저장되기는 하는데, 출금자명이 null로 저장되는 버그
출금 시 거래 내역 테이블에 정보를 저장할 때 request에서 가져온 출금자명을 입금자명에 저장하고 있었음.

**🌷 TO-BE**
- 거래 내역 테이블에 거래 저장 시 출금자명에 저장하도록 수정

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 =>  추가 예정
- [x] API 테스트 